### PR TITLE
Removed hardcoded secret id from tests. 

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,3 +30,4 @@ jobs:
           TSS_USERNAME: ${{ secrets.TSS_USERNAME }}
           TSS_PASSWORD: ${{ secrets.TSS_PASSWORD }}
           TSS_TENANT: ${{ secrets.TSS_TENANT }}
+          SECRET_ID: ${{ secrets.SECRET_ID }}

--- a/README.md
+++ b/README.md
@@ -126,11 +126,10 @@ Valid credentials are required to run the unit tests. The credentials should be 
 export TSS_USERNAME=myusername
 export TSS_PASSWORD=mysecretpassword
 export TSS_TENANT=mytenant
+export SECRET_ID=42
 ```
 
-The tests assume that the user associated with the specified `TSS_USERNAME` and `TSS_PASSWORD` can read the secret with ID `1`, and that the Secret itself contains `username` and `password` fields.
-
-> Note: The secret ID can be changed manually in `test_server.py` to a secret ID that the user can access.
+The tests assume that the user associated with the specified `TSS_USERNAME` and `TSS_PASSWORD` can read the secret to be fetched, and that the Secret itself contains `username` and `password` fields.
 
 To run the tests with `tox`:
 

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ def env_vars():
         "username": os.getenv("TSS_USERNAME"),
         "password": os.getenv("TSS_PASSWORD"),
         "tenant": os.getenv("TSS_TENANT"),
+        "secret_id": os.getenv("SECRET_ID")
     }
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,6 @@ import pytest
 from thycotic.secrets.server import (
     AccessTokenAuthorizer,
     SecretServer,
-    SecretServerV0,
     SecretServerClientError,
     SecretServerError,
     ServerSecret,
@@ -16,7 +15,7 @@ def test_bad_url(env_vars, authorizer):
         authorizer,
     )
     with pytest.raises(SecretServerError):
-        bad_server.get_secret(1)
+        bad_server.get_secret(env_vars["secret_id"])
 
 
 def test_token_url(env_vars, authorizer):
@@ -38,13 +37,16 @@ def test_access_token_authorizer(env_vars, authorizer):
         SecretServer(
             f"https://{env_vars['tenant']}.secretservercloud.com/",
             AccessTokenAuthorizer(authorizer.get_access_token()),
-        ).get_secret(1)["id"]
-        == 1
+        ).get_secret(env_vars["secret_id"])["id"]
+        == int(env_vars['secret_id'])
     )
 
 
-def test_server_secret(secret_server):
-    assert ServerSecret(**secret_server.get_secret(1)).id == 1
+def test_server_secret(env_vars, secret_server):
+    assert (
+        ServerSecret(**secret_server.get_secret(env_vars["secret_id"])).id
+        == int(env_vars["secret_id"])
+    )
 
 
 def test_nonexistent_secret(secret_server):

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,6 @@ passenv =
     TSS_USERNAME
     TSS_PASSWORD
     TSS_TENANT
+    SECRET_ID
 commands =
     pytest


### PR DESCRIPTION
Removed hardcoded secret id from tests. The secret id should now be pulled from the .env file using the `SECRET_ID` variable name. 