### PR TITLE
Removed dataclass backport dependency

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ jobs:
     environment: testing
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ When using a self-signed certificate for SSL, the `REQUESTS_CA_BUNDLE` environme
 
 ## Create a Build Environment (optional)
 
-The SDK requires [Python 3.6](https://www.python.org/downloads/) or higher.
+The SDK requires [Python 3.7](https://www.python.org/downloads/) or higher.
 
 First, ensure Python is in `$PATH`, then run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ author-email = "adam@migus.org"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -17,8 +16,7 @@ classifiers = [
 ]
 description-file = "README.md"
 requires = [
-    "dataclasses >= 0.6",
     "requests >= 2.12.5"
 ]
-requires-python=">=3.6"
+requires-python=">=3.7"
 dist-name = "python-tss-sdk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.22.0
-dataclasses>=0.6
 tox
 pytest
 python-dotenv

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # Docs for tox config -> https://tox.readthedocs.io/en/latest/config.html
 
 [tox]
-envlist = 3.6, 3.7, 3.8, 3.9, 3.10
+envlist = 3.7, 3.8, 3.9, 3.10
 isolated_build = True
 skipsdist = True
 
@@ -14,7 +14,6 @@ skipsdist = True
 deps =
     pytest
     requests
-    dataclasses
     python-dotenv
 passenv =
     TSS_USERNAME


### PR DESCRIPTION
The removal of this backport drops support for Python 3.6, [which is now EOL](https://endoflife.date/python).

Fixes #32 